### PR TITLE
github: use explicit branch name for workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Deploy site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The '$default-branch' variable appears to only be valid in workflow templates, not workflows.

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>