### PR TITLE
mkaestatic: add compact code to support mistune v3

### DIFF
--- a/mkaestatic.py
+++ b/mkaestatic.py
@@ -199,16 +199,32 @@ def get_markdown_renderer( url_transform ):
         return mistune.Markdown(renderer=MyRenderer(escape=False, use_xhtml=True))
 
     except AttributeError: # Keep this to only support mistune 2
-        class MyRenderer( mistune.HTMLRenderer ):
-            def link(self, link, text, title):
-                link = url_transform(link)
-                return super(MyRenderer, self).link(link, text, title)
+        try:
+            class Dummy( mistune.AstRenderer ):
+                pass
 
-            def image(self, src, alt_text, title):
-                src = url_transform(src)
-                return super(MyRenderer, self).image(src, alt_text, title)
-                
-        return mistune.create_markdown(renderer=MyRenderer(escape=False))
+            class MyRenderer( mistune.HTMLRenderer ):
+                def link(self, link, text, title):
+                    link = url_transform(link)
+                    return super(MyRenderer, self).link(link, text, title)
+
+                def image(self, src, alt_text, title):
+                    src = url_transform(src)
+                    return super(MyRenderer, self).image(src, alt_text, title)
+
+            return mistune.create_markdown(renderer=MyRenderer(escape=False))
+
+        except AttributeError:
+            class MyRenderer( mistune.HTMLRenderer ):
+                def link(self, text, url, title=None):
+                    url = url_transform(url)
+                    return super(MyRenderer, self).link(text, url, title)
+
+                def image(self, alt, url, title=None):
+                    url = url_transform(url)
+                    return super(MyRenderer, self).image(alt, url, title)
+
+            return mistune.create_markdown(renderer=MyRenderer(escape=False))
 
 def render( md_source, template_fn, site_cfg, config, cfg_tree, input_root ):
     ''' This function renders the markdown source to html code. 


### PR DESCRIPTION
Module mistune again changed the API. They changed signature of HTMLRenderer functions and dropped AstRenderer.

The number of parameters is the same for link() and image() functions so it doesn't fails when defining our wrappers, instead it fails when they are called with the following error:

    TypeError: get_markdown_renderer.<locals>.MyRenderer.link() got an unexpected keyword argument 'url'

As we know that AstRenderer doesn't exist in v3 we can use it the same way to get AttributeError exception.