### PR TITLE
ci: deploy hidden _site files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Upload artifacts
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v4
+        with:
+          include-hidden-files: true
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Needed for .well-known directory for flatpak app verification: https://github.com/actions/upload-artifact?tab=readme-ov-file#uploading-hidden-files