### PR TITLE
ci: actually fix publishing flatpak verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,10 +40,24 @@ jobs:
           cp -a appdata _site/
           cp -a jquery.fancybox _site/
           cp -a .well-known _site/
-      - name: Upload artifacts
-        # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v4
+      - name: Archive artifact
+        # Derived from upload-pages-artifact@v4
+        # But we need hidden files included for flatpak .well-known
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory _site \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
         with:
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
           include-hidden-files: true
 
   # Deployment job


### PR DESCRIPTION
I was confused in the previous commit. `actions/upload-pages-artifact`
does not support hidden files, but `actions/upload-artifact` does.

Drop use of `actions/upload-pages-artifact` and roll it by hand.
I confirmed this works correctly on my fork